### PR TITLE
Remove div dimensions

### DIFF
--- a/src/components/ReactTypeformEmbed/ReactTypeformEmbed.css
+++ b/src/components/ReactTypeformEmbed/ReactTypeformEmbed.css
@@ -7,11 +7,6 @@
   overflow: hidden;
 }
 
-.ReactTypeformEmbed > div {
-  width: 100%;
-  height: 100%;
-}
-
 .ReactTypeformEmbed__error {
   font-size: large;
 }


### PR DESCRIPTION
The internal div not need to have space dimensions. This cause that place the element above other HTML elements, making impossible interact with the element below of the div.