### PR TITLE
Hide root dom in popup mode

### DIFF
--- a/src/components/ReactTypeformEmbed/ReactTypeformEmbed.test.js
+++ b/src/components/ReactTypeformEmbed/ReactTypeformEmbed.test.js
@@ -21,4 +21,9 @@ describe('<ReactTypeformEmbed />', () => {
     const wrapper = mount(<ReactTypeformEmbed url={url} />);
     expect(wrapper.props().url).toEqual(url);
   });
+
+  it('should hide root node if props.popup is true', () => {
+    const wrapper = shallow(<ReactTypeformEmbed url={url} popup={true}/>);
+    expect(wrapper.prop('style').display).toEqual('none');
+  });
 });

--- a/src/components/ReactTypeformEmbed/index.js
+++ b/src/components/ReactTypeformEmbed/index.js
@@ -42,7 +42,10 @@ class ReactTypeformEmbed extends Component {
   }
 
   render() {
-    const style = Object.assign({}, styleDefault, this.props.style);
+    const styleBase = this.props.popup
+      ? { display: 'none' }
+      : {}
+    const style = Object.assign(styleBase, styleDefault, this.props.style);
 
     return <div className="ReactTypeformEmbed" ref={tf => this.typeformElm = tf} style={style} />;
   }


### PR DESCRIPTION
a minor patch for https://github.com/alexgarces/react-typeform-embed/issues/20